### PR TITLE
API, doc and CI cleanups for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 [Ply](http://paulbourke.net/dataformats/ply/) polygon file format, also called
 the Stanford triangle format.
 
+[![linux/osx build status](https://travis-ci.org/FugroRoames/PlyIO.jl.svg?branch=master)](https://travis-ci.org/FugroRoames/PlyIO.jl)
+[![windows build status](https://ci.appveyor.com/api/projects/status/y4ycgwp4rm49wrt8?svg=true)](https://ci.appveyor.com/project/c42f/plyio-jl)
+
 ## Quick start
 
 ### Writing ply

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ the Stanford triangle format.
 
 ## Quick start
 
+### Writing ply
+
 Here's an example of how to write a basic ply file containing random triangles
 and edges:
 
@@ -42,22 +44,86 @@ end
 push!(ply, PlyElement("edge", vertex_index))
 
 # For the sake of the example, ascii format is used, the default binary mode is faster.
-save_ply(ply, "test.ply", ascii=true)
+save_ply(ply, "example1.ply", ascii=true)
 ```
 
 Opening this file using a program like
-[displaz](https://github.com/c42f/displaz), for example using `displaz test.ply`,
+[displaz](https://github.com/c42f/displaz), for example using `displaz example1.ply`,
 you should see something like
 
 ![Example one](doc/example1.png)
 
-## The file format
 
-In the abstract, the ply format is a container for a set of named tables of
-numeric data.  Each table, or **element**, has several named columns or
-**properties**.  Properties can be either simple numeric values (floating point
-or signed/unsigned integers), or variable length lists of such numeric values.
+### Reading ply
 
-For geometric data, there are some loose
-[naming conventions](http://paulbourke.net/dataformats/ply/).  Unfortunately
-there's no official standard.
+Reading the ply file generated above is quite simple:
+
+```julia
+julia> using PlyIO
+
+julia> ply = load_ply("example1.ply")
+PlyIO.Ply with header:
+ ply
+ format ascii 1.0
+ comment An example ply file
+ element vertex 1000
+ property float64 x
+ property float64 y
+ property float64 z
+ property float64 r
+ property float64 g
+ property float64 b
+ element face 1000
+ property list int32 int32 vertex_index
+ element edge 1000
+ property list int32 int32 vertex_index
+ end_header
+
+julia> ply["vertex"]
+PlyElement "vertex" of length 1000 with properties ["x", "y", "z", "r", "g", "b"]
+
+julia> ply["vertex"]["x"]
+1000-element PlyIO.ArrayProperty{Float64,String} "x":
+ -0.472592
+  1.04326
+ -0.982202
+ ⋮
+ -2.55605
+  0.773923
+ -2.10675
+```
+
+## API
+
+### The file format
+
+Conceptually, the ply format is a container for a set of named tables of numeric
+data.  Each table, or **element**, has several named columns or **properties**.
+Properties can be either simple numeric arrays (floating point or
+signed/unsigned integers), or arrays of variable length lists of such numeric
+values.
+
+As described, ply is quite a generic format but it's primarily used for
+geometric data. For this use there are some loose
+[naming conventions](http://paulbourke.net/dataformats/ply/) which attach
+geometric meaning to certian combinations of element and property names.
+Unfortunately there's no official standard.
+
+### Document object model
+
+Ply elements are represented with the `PlyElement` type which is a list of
+properties which may be looked up by name.
+
+Properties may be represented by an `AbstractArray` type which has the the
+`plyname` function defined, which should return a name for the property.  The
+builtin types `ArrayProperty` and `ListProperty` are used as containers for data
+when reading a ply file.
+
+The `Ply` type is a container for several interleaved `PlyElement` and
+`PlyComment` fields, in the order which would be observed in a standard ply
+header.
+
+### Reading and writing
+
+To read and write `Ply` objects from files or `IO` streams, use the functions
+`load_ply()` and `save_ply()`.

--- a/doc/example1.jl
+++ b/doc/example1.jl
@@ -1,0 +1,33 @@
+using PlyIO
+
+ply = Ply()
+push!(ply, PlyComment("An example ply file"))
+
+nverts = 1000
+
+# Random vertices with position and color
+vertex = PlyElement("vertex",
+                    ArrayProperty("x", randn(nverts)),
+                    ArrayProperty("y", randn(nverts)),
+                    ArrayProperty("z", randn(nverts)),
+                    ArrayProperty("r", rand(nverts)),
+                    ArrayProperty("g", rand(nverts)),
+                    ArrayProperty("b", rand(nverts)))
+push!(ply, vertex)
+
+# Some triangular faces
+vertex_index = ListProperty("vertex_index", Int32, Int32)
+for i=1:nverts
+   push!(vertex_index, rand(0:nverts-1,3))
+end
+push!(ply, PlyElement("face", vertex_index))
+
+# Some edges
+vertex_index = ListProperty("vertex_index", Int32, Int32)
+for i=1:nverts
+   push!(vertex_index, rand(0:nverts-1,2))
+end
+push!(ply, PlyElement("edge", vertex_index))
+
+# For the sake of the example, ascii format is used, the default binary mode is faster.
+save_ply(ply, "example1.ply", ascii=true)

--- a/src/PlyIO.jl
+++ b/src/PlyIO.jl
@@ -3,7 +3,8 @@ __precompile__()
 module PlyIO
 
 # Types for the ply data model
-export Ply, PlyElement, PlyComment, PlyProperty, ArrayProperty, ListProperty
+export Ply, PlyElement, PlyComment, ArrayProperty, ListProperty
+export plyname  # Is there something in base we could overload for this?
 
 # High level file IO
 # (TODO: FileIO?)

--- a/src/io.jl
+++ b/src/io.jl
@@ -43,7 +43,7 @@ function read_header(ply_file)
     @assert readline(ply_file) == "ply\n"
     element_name = ""
     element_numel = 0
-    element_props = PlyProperty[]
+    element_props = Vector{AbstractVector}()
     elements = PlyElement[]
     comments = PlyComment[]
     format = nothing
@@ -64,7 +64,7 @@ function read_header(ply_file)
         elseif startswith(line, "element")
             if !isempty(element_name)
                 push!(elements, PlyElement(element_name, element_numel, element_props))
-                element_props = PlyProperty[]
+                element_props = Vector{AbstractVector}()
             end
             tok, element_name, element_numel = split(line)
             @assert tok == "element"

--- a/src/io.jl
+++ b/src/io.jl
@@ -22,6 +22,17 @@ function ply_type(type_name)
     end
 end
 
+ply_type_name(::Type{UInt8})    = "uint8"
+ply_type_name(::Type{UInt16})   = "uint16"
+ply_type_name(::Type{UInt32})   = "uint32"
+ply_type_name(::Type{UInt64})   = "uint64"
+ply_type_name(::Type{Int8})     = "int8"
+ply_type_name(::Type{Int16})    = "int16"
+ply_type_name(::Type{Int32})    = "int32"
+ply_type_name(::Type{Int64})    = "int64"
+ply_type_name(::Type{Float32})  = "float32"
+ply_type_name(::Type{Float64})  = "float64"
+
 ply_type_name(::UInt8)    = "uint8"
 ply_type_name(::UInt16)   = "uint16"
 ply_type_name(::UInt32)   = "uint32"
@@ -98,8 +109,8 @@ function write_header_field{T,Names<:PropNameList}(stream::IO, prop::ArrayProper
     end
 end
 
-function write_header_field(stream::IO, prop::ListProperty)
-    println(stream, "property list $(ply_type_name(prop.start_inds)) $(ply_type_name(prop.data)) $(prop.name)")
+function write_header_field{S}(stream::IO, prop::ListProperty{S})
+    println(stream, "property list $(ply_type_name(S)) $(ply_type_name(prop.data)) $(prop.name)")
 end
 
 
@@ -179,9 +190,9 @@ end
 function write_binary_value(stream::IO, prop::ArrayProperty, index)
     write(stream, prop.data[index])
 end
-function write_binary_value(stream::IO, prop::ListProperty, index)
+function write_binary_value{S}(stream::IO, prop::ListProperty{S}, index)
     len = prop.start_inds[index+1] - prop.start_inds[index]
-    write(stream, len)
+    write(stream, convert(S, len))
     esize = sizeof(eltype(prop.data))
     unsafe_write(stream, pointer(prop.data) + esize*(prop.start_inds[index]-1), esize*len)
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -61,11 +61,11 @@ with a name which can be retrieved using `plyname()`.
 """
 type ListProperty{S,T} <: AbstractVector{Vector{T}}
     name::String
-    start_inds::Vector{S}
+    start_inds::Vector{Int}
     data::Vector{T}
 end
 
-ListProperty{S,T}(name, ::Type{S}, ::Type{T}) = ListProperty(String(name), ones(S,1), Vector{T}())
+ListProperty{S,T}(name, ::Type{S}, ::Type{T}) = ListProperty{S,T}(String(name), ones(Int,1), Vector{T}())
 
 function ListProperty(name::AbstractString, a::AbstractVector)
     # Construct list from an array of arrays
@@ -137,7 +137,7 @@ function Base.length(elem::PlyElement)
     len = length(elem.properties[1])
     if any(prop->len != length(prop), elem.properties)
         proplens = [length(p) for p in elem.properties]
-        throw(ErrorException("Element $(elname(elme)) has inconsistent property lengths: $proplens"))
+        throw(ErrorException("Element $(plyname(elem)) has inconsistent property lengths: $proplens"))
     end
     return len
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,12 +1,24 @@
 #-------------------------------------------------------------------------------
 # Types representing the ply data model
 
-abstract PlyProperty
+"""
+    plyname(data)
+
+Return the name that `data` is associated with when serialized in a ply file
+"""
+function plyname
+end
 
 typealias PropNameList Union{AbstractVector,Tuple}
 
 #--------------------------------------------------
-type ArrayProperty{T,Name} <: PlyProperty
+"""
+    ArrayProperty(name, T)
+
+A ply `property \$T \$name`, modelled as an abstract vector, with a name which
+can be retrieved using `plyname()`.
+"""
+type ArrayProperty{T,Name} <: AbstractVector{T}
     name::Name
     data::Vector{T}
 end
@@ -23,108 +35,158 @@ end
 
 ArrayProperty{T}(name::AbstractString, ::Type{T}) = ArrayProperty(String(name), Vector{T}())
 
+Base.summary(prop::ArrayProperty) = "$(length(prop))-element $(typeof(prop)) \"$(plyname(prop))\""
+
+# AbstractArray methods
+Base.size(prop::ArrayProperty) = size(prop.data)
+Base.getindex(prop::ArrayProperty, i::Int) = prop.data[i]
+Base.setindex!(prop::ArrayProperty, v, i::Int) = prop.data[i] = v
+Base.linearindexing(prop::ArrayProperty) = Base.LinearFast()
+
+# List methods
 Base.resize!(prop::ArrayProperty, len) = resize!(prop.data, len)
 Base.push!(prop::ArrayProperty, val) = push!(prop.data, val)
 
-Base.length(prop::ArrayProperty) = length(prop.data)
-Base.getindex(prop::ArrayProperty, i) = prop.data[i]
-
-Base.start(prop::ArrayProperty) = start(prop.data)
-Base.next(prop::ArrayProperty, state) = next(prop.data, state)
-Base.done(prop::ArrayProperty, state) = done(prop.data, state)
+# Ply methods
+plyname(prop::ArrayProperty) = prop.name
 
 
 #--------------------------------------------------
-type ListProperty{S,T} <: PlyProperty
+"""
+    ListProperty(name, S, T)
+    ListProperty(name, list_of_vectors)
+
+A ply `property list \$S \$T \$name`, modelled as a abstract vector of vectors,
+with a name which can be retrieved using `plyname()`.
+"""
+type ListProperty{S,T} <: AbstractVector{Vector{T}}
     name::String
     start_inds::Vector{S}
     data::Vector{T}
 end
+
 ListProperty{S,T}(name, ::Type{S}, ::Type{T}) = ListProperty(String(name), ones(S,1), Vector{T}())
-function ListProperty(name, a::Array)
-    prop = ListProperty(String(name), ones(Int32,1), Vector{eltype(a[1])}())
-    for ai in a
-        push!(prop, ai)
-    end
+
+function ListProperty(name::AbstractString, a::AbstractVector)
+    # Construct list from an array of arrays
+    prop = ListProperty(name, Int32, eltype(a[1]))
+    foreach(ai->push!(prop,ai), a)
     prop
 end
 
+Base.summary(prop::ListProperty) = "$(length(prop))-element $(typeof(prop)) \"$(plyname(prop))\""
+
+# AbstractArray methods
+Base.length(prop::ListProperty) = length(prop.start_inds)-1
+Base.size(prop::ListProperty) = (length(prop),)
+Base.getindex(prop::ListProperty, i::Int) = prop.data[prop.start_inds[i]:prop.start_inds[i+1]-1]
+Base.linearindexing(prop::ListProperty) = Base.LinearFast()
+# TODO: Do we need Base.setindex!() ?  Hard to provide with above formulation...
+
+# List methods
 function Base.resize!(prop::ListProperty, len)
     resize!(prop.start_inds, len+1)
     prop.start_inds[1] = 1
 end
-
 function Base.push!(prop::ListProperty, list)
     push!(prop.start_inds, prop.start_inds[end]+length(list))
     append!(prop.data, list)
 end
 
-Base.length(prop::ListProperty) = length(prop.start_inds)-1
-Base.getindex(prop::ListProperty, i) = prop.data[prop.start_inds[i]:prop.start_inds[i+1]-1]
-
-Base.start(prop::ListProperty) = 1
-Base.next(prop::ListProperty, state) = (prop[state], state+1)
-Base.done(prop::ListProperty, state) = state > length(prop)
+# Ply methods
+plyname(prop::ListProperty) = prop.name
 
 
 #--------------------------------------------------
+"""
+    PlyElement(name, [len | props...])
+
+Construct a ply `element \$name \$len`, containing a list of properties with a
+name which can be retrieved using `plyname`.  Properties can be accessed with
+the array interface, or looked up by indexing with a string.
+
+The expected length `len` is used if it is set, otherwise the length shared by
+the property vectors is used.
+"""
 type PlyElement
     name::String
-    len::Int
-    properties::Vector{PlyProperty}
+    prior_len::Int  # Length as expected, or as read from file
+    properties::Vector
 end
 
-PlyElement(name::AbstractString) = PlyElement(name, 0, Vector{PlyProperty}())
-function PlyElement(name::AbstractString, props::PlyProperty...)
-    el = PlyElement(name)
-    for prop in props
-        push!(el, prop)
-    end
-    el
+PlyElement(name::AbstractString, len::Int=-1) = PlyElement(name, len, Vector{Any}())
+
+function PlyElement(name::AbstractString, props::AbstractVector...)
+    PlyElement(name, -1, collect(props))
 end
-
-function Base.push!(elem::PlyElement, prop)
-    if isempty(elem.properties)
-        elem.len = length(prop)
-    elseif elem.len != length(elem.properties[1])
-        throw(ErrorException("Property length $(length(prop)) doesn't match element length $(length(elem))"))
-    end
-    push!(elem.properties, prop)
-end
-
-Base.start(elem::PlyElement) = start(elem.properties)
-Base.next(elem::PlyElement, state) = next(elem.propertes, state)
-Base.done(elem::PlyElement, state) = done(elem.propertes, state)
-
-Base.length(elem::PlyElement) = elem.len
 
 function Base.show(io::IO, elem::PlyElement)
-    prop_names = join(["\"$(prop.name)\"" for prop in elem.properties], ", ")
-    print(io, "PlyElement \"$(elem.name)\" of length $(length(elem)) with properties [$prop_names]")
+    prop_names = join(["\"$(plyname(prop))\"" for prop in elem.properties], ", ")
+    print(io, "PlyElement \"$(plyname(elem))\" of length $(length(elem)) with properties [$prop_names]")
+end
+
+# Table-like methods
+function Base.length(elem::PlyElement)
+    # Check that lengths are consistent and return the length
+    if elem.prior_len != -1
+        return elem.prior_len
+    end
+    if isempty(elem.properties)
+        return 0
+    end
+    len = length(elem.properties[1])
+    if any(prop->len != length(prop), elem.properties)
+        proplens = [length(p) for p in elem.properties]
+        throw(ErrorException("Element $(elname(elme)) has inconsistent property lengths: $proplens"))
+    end
+    return len
 end
 
 function Base.getindex(element::PlyElement, prop_name)
+    # Get first property with a matching name
     for prop in element.properties
-        if prop.name == prop_name
+        if plyname(prop) == prop_name
             return prop
         end
     end
-    error("property $prop_name not found in Ply element $(element.name)")
+    error("property $prop_name not found in Ply element $(plyname(element))")
 end
+
+# List methods
+Base.start(elem::PlyElement) = start(elem.properties)
+Base.next(elem::PlyElement, state) = next(elem.propertes, state)
+Base.done(elem::PlyElement, state) = done(elem.propertes, state)
+Base.push!(elem::PlyElement, prop) = push!(elem.properties, prop)
+
+# Ply methods
+plyname(elem::PlyElement) = elem.name
 
 
 #--------------------------------------------------
+"""
+    PlyComment(string)
+
+A ply comment.
+"""
 immutable PlyComment
     comment::String
     location::Int # index of previous element
 end
 
-PlyComment(comment::AbstractString) = PlyComment(comment, -1)
+PlyComment(string::AbstractString) = PlyComment(string, -1)
 
 Base.:(==)(a::PlyComment, b::PlyComment) = a.comment == b.comment && a.location == b.location
 
 
 #--------------------------------------------------
+"""
+    Ply()
+
+Container for the contents of a ply file.  This type directly models the
+contents of the header.  Ply elements and comments can be added using
+`push!()`, elements can be iterated over with the standard iterator
+interface, and looked up by indexing with a string.
+"""
 type Ply
     elements::Vector{PlyElement}
     comments::Vector{PlyComment}
@@ -132,22 +194,29 @@ end
 
 Ply() = Ply(Vector{PlyElement}(), Vector{String}())
 
+function Base.show(io::IO, ply::Ply)
+    buf = IOBuffer()
+    write_header(ply, buf, true)
+    headerstr = takebuf_string(buf)
+    headerstr = replace(strip(headerstr), "\n", "\n ")
+    print(io, "$Ply with header:\n $headerstr")
+end
+
+# List methods
 Base.push!(ply::Ply, el::PlyElement) = push!(ply.elements, el)
 Base.push!(ply::Ply, c::PlyComment) = push!(ply.comments, PlyComment(c.comment, length(ply.elements)+1))
 
-Base.start(ply::Ply) = start(ply.elements)
-Base.next(ply::Ply, state) = next(ply.elements, state)
-Base.done(ply::Ply, state) = done(ply.elements, state)
-
-function Base.show(io::IO, ply::Ply)
-    print(io, "Ply with elements [$(join(["\"$(elem.name)\"" for elem in ply.elements], ", "))]")
-end
-
-function Base.getindex(ply::Ply, elem_name)
+# Element search and iteration
+function Base.getindex(ply::Ply, elem_name::AbstractString)
     for elem in ply.elements
-        if elem.name == elem_name
+        if plyname(elem) == elem_name
             return elem
         end
     end
     error("$elem_name not found in Ply element list")
 end
+
+Base.start(ply::Ply) = start(ply.elements)
+Base.next(ply::Ply, state) = next(ply.elements, state)
+Base.done(ply::Ply, state) = done(ply.elements, state)
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ using Base.Test
     push!(ply, PlyElement("A",
                           ArrayProperty("x", UInt8[1,2,3]),
                           ArrayProperty("y", Float32[1.1,2.2,3.3]),
-                          ListProperty("a_list", [[0,1], [2,3,4], [5]])))
+                          ListProperty("a_list", Vector{Int64}[[0,1], [2,3,4], [5]])))
     push!(ply, PlyComment("PlyComment about B"))
     push!(ply, PlyComment("PlyComment about B 2"))
     push!(ply, PlyElement("B",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ using PlyIO
 using StaticArrays
 using Base.Test
 
+@testset "PlyIO" begin
+
 
 @testset "simple" begin
     ply = Ply()
@@ -75,10 +77,9 @@ end
         newply = load_ply("roundtrip_test_tmp.ply")
 
         # TODO: Need a better way to access the data arrays than this.
-        @test newply["vertex"]["x"].data == x
-        @test newply["vertex"]["y"].data == y
-        @test newply["face"]["vertex_index"].start_inds == vertex_index.start_inds
-        @test newply["face"]["vertex_index"].data == vertex_index.data
+        @test newply["vertex"]["x"] == x
+        @test newply["vertex"]["y"] == y
+        @test newply["face"]["vertex_index"] == vertex_index
 
         @test newply.comments == [PlyComment("A comment",1), PlyComment("Blah blah",1)]
     end
@@ -117,3 +118,5 @@ end
     """
 end
 
+
+end # @testset PlyIO


### PR DESCRIPTION
I figured I should get the documentation into a better shape before tagging.

This led to fixing the API up a bit when reading ply files (as opposed to writing them which already seems ok): properties are now just abstract arrays with a name.

Also enable travis and appveyor, and fix a few niggles there.
