### PR TITLE
always write space delimiters

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -240,7 +240,7 @@ function write_ascii_value(stream::IO, prop::ArrayProperty{<:AbstractArray}, ind
     p = prop.data[index]
     for i = 1:length(p)
         if i != 1
-            write(stream, '\t')
+            write(stream, ' ')
         end
         print(stream, p[i])
     end
@@ -366,7 +366,7 @@ function save_ply(ply, stream::IO; ascii::Bool=false)
             for i=1:length(element)
                 for (j,property) in enumerate(element.properties)
                     if j != 1
-                        write(stream, '\t')
+                        write(stream, ' ')
                     end
                     write_ascii_value(stream, property, i)
                 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,11 +61,11 @@ end
     property int16 g
     comment Final comment
     end_header
-    1	1.1	2 0 1
-    2	2.2	3 2 3 4
-    3	3.3	1 5
-    -1	1
-    1	1
+    1 1.1 2 0 1
+    2 2.2 3 2 3 4
+    3 3.3 1 5
+    -1 1
+    1 1
     """
 end
 
@@ -90,10 +90,7 @@ end
     element B 3
     property list int32 int64 a_list
     end_header
-    0 
-    0 
-    0 
-    """
+    0 \n0 \n0 \n"""
 end
 
 @testset "roundtrip" begin
@@ -197,9 +194,9 @@ end
     property uint8 g
     property uint8 b
     end_header
-    1.0	2.0
-    3.0	4.0
-    1	2	3
+    1.0 2.0
+    3.0 4.0
+    1 2 3
     """
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,7 +90,10 @@ end
     element B 3
     property list int32 int64 a_list
     end_header
-    0 \n0 \n0 \n"""
+    0 
+    0 
+    0 
+    """
 end
 
 @testset "roundtrip" begin


### PR DESCRIPTION
Right now, for reasons I don't fully understand, sometimes tabs are used as delimiters when writing, and sometimes spaces. As far as I understand that is perfectly legal for ply. For reading any of these is supported:

https://github.com/JuliaGeometry/PlyIO.jl/blob/v1.1.1/src/io.jl#L178-L179

I'd like to propose to change the delimiter written to files to use spaces. I tried to open a Ply file written by this package in QGIS and found that the parser in MDAL does not support tabs. I could of course fix that, but that seems much more involved, and perhaps this is a bit more consistent / common anyway.